### PR TITLE
Bump msgpack to 1.8.3 to fix use-after-free advisory

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,7 +140,7 @@ GEM
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
-    msgpack (1.8.1)
+    msgpack (1.8.3)
     net-imap (0.6.4.1)
       date
       net-protocol


### PR DESCRIPTION
## Why

The `scan_dependencies` (bundler-audit) job is failing on `main`. `msgpack` 1.8.1 is affected by [GHSA-4mrv-5p47-p938](https://github.com/advisories/GHSA-4mrv-5p47-p938) — a use-after-free in `MessagePack::Buffer#clear` enabling cross-buffer disclosure, fixed in 1.8.2. The advisory was published to ruby-advisory-db after PR #119 merged, so it surfaced on the next main run.

## Change

Conservative bump of the transitive `msgpack` dependency 1.8.1 → 1.8.3. One-line lockfile change.

## Verification

`bundle exec bundler-audit check` → **No vulnerabilities found**

🤖 Generated with [Claude Code](https://claude.com/claude-code)